### PR TITLE
Replaced one inv() call with pinv() in CalcEndEffectorWrench()

### DIFF
--- a/kinova_station/common.py
+++ b/kinova_station/common.py
@@ -78,7 +78,7 @@ class EndEffectorWrenchCalculator(LeafSystem):
 
         # Compute jacobian pseudoinverse
         Minv = np.linalg.inv(M)
-        Lambda = np.linalg.inv(J@Minv@J.T)
+        Lambda = np.linalg.pinv(J@Minv@J.T)
         Jbar = Lambda@J@Minv
 
         # Compute wrench (spatial force) applied at end-effector


### PR DESCRIPTION
Some of my simulations recently were breaking because of a call to `np.linalg.inv()` in the `CalcEndEffectorWrench()` function (the Jacobian matrix was not full rank and led to line 81 trying to invert a singular matrix). By replacing one of the calls with `np.linalg.pinv()` my simulations work; Do you know if this modification makes sense?

The errors don't appear to happen for 7dof systems, but happen immediately when using the 6dof model at the beginning of my own simulation scripts. I've tested this change on both the 6dof and 7dof versions of the KinovaStation object.